### PR TITLE
Fix change in Python API

### DIFF
--- a/electrode/transformations.c
+++ b/electrode/transformations.c
@@ -2124,7 +2124,7 @@ static int axis2tuple(
     if (PyString_Check(axes) && (PyString_Size(axes) == 4)) {
         char *s = PyString_AS_STRING(axes);
 #else
-    if (PyUnicode_Check(axes) && (PyUnicode_GetSize(axes) == 4)) {
+    if (PyUnicode_Check(axes) && (PyUnicode_GET_LENGTH(axes) == 4)) {
         char *s = PyBytes_AsString(PyUnicode_AsASCIIString(axes));
 #endif
         int hash = *((int *)s);


### PR DESCRIPTION
`PyUnicode_GetSize` does not seem to exist anymore, use `PyUnicode_GET_LENGTH` instead.