### PR TITLE
Fix attribute error

### DIFF
--- a/electrode/utils.py
+++ b/electrode/utils.py
@@ -568,7 +568,7 @@ def mathieu(r, *a):
       (see numpy.linalg.eig())
     """
     n = a[0].shape[0]
-    m = np.zeros((2*r+1, 2*r+1, 2, 2, n, n), dtype=np.complex)
+    m = np.zeros((2*r+1, 2*r+1, 2, 2, n, n), dtype=complex)
     for l in range(2*r+1):
         # derivative on the diagonal
         m[l, l, 0, 0] = m[l, l, 1, 1] = np.identity(n)*2j*(l-r)


### PR DESCRIPTION
Fix following error:
```
AttributeError: module 'numpy' has no attribute 'complex'.
`np.complex` was a deprecated alias for the builtin `complex`. To avoid
this error in existing code, use `complex` by itself. Doing this will
not modify any behavior and is safe. If you specifically wanted the
numpy scalar type, use `np.complex128` here.
The aliases was originally deprecated in NumPy 1.20; for more details
and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

The fix should also be backwards compatible.