### PR TITLE
Replace sphinx extension `pngmath` by `imgmath`

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,7 +29,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
 #    'sphinx.ext.coverage',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
 #    'sphinx.ext.inheritance_diagram',


### PR DESCRIPTION
`pngmath` module was removed since 1.8. The commit changes the extension to its successor `sphinx.ext.imgmath`.